### PR TITLE
feat: allow local ui origin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,9 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors({
+    origin: 'http://localhost:8080',
+  });
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- enable CORS for http://localhost:8080 in Nest bootstrap

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afa322b308832583ce7e7c21794d96